### PR TITLE
Move Google Analytics ID to config

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -13,8 +13,15 @@ Set:
 - `supabaseUrl` — your Supabase project URL  
 - `supabaseAnonKey` — anon or publishable key (safe for browser; protect data with RLS)  
 - `donateUrl` — optional  
+- `analyticsId` — optional Google Analytics Measurement ID (for example `G-XXXXXXXXXX`). Leave empty to disable analytics.
 
 `config.js` is gitignored in the public repo.
+
+### Google Analytics (optional)
+
+To enable Google Analytics on your deployment, set `analyticsId` in `web/config.js`.
+
+If `analyticsId` is left empty, no Google Analytics script is loaded.
 
 ## Deploy
 

--- a/web/config.example.js
+++ b/web/config.example.js
@@ -4,5 +4,6 @@ window.CAREEROPS_CONFIG = {
   supabaseUrl: 'https://YOUR_PROJECT.supabase.co',
   supabaseAnonKey: 'YOUR_SUPABASE_ANON_OR_PUBLISHABLE_KEY',
   // optional
-  donateUrl: ''
+  donateUrl: '',
+  analyticsId: ''
 }

--- a/web/index.html
+++ b/web/index.html
@@ -5,13 +5,32 @@
 <!-- match-score-fix: 2026-07-23-v3-builder-hero -->
 <!-- gaps-ux-fix: 2026-07-23-v2-materials-insert -->
 
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZXKVCL5TGG"></script>
+<!-- Load local configuration if present -->
 <script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-ZXKVCL5TGG');
+  window.CAREEROPS_CONFIG = window.CAREEROPS_CONFIG || {};
+</script>
+<script src="config.js"></script>
+
+<script>
+  const analyticsId = window.CAREEROPS_CONFIG?.analyticsId;
+
+  if (analyticsId) {
+    const gaScript = document.createElement("script");
+    gaScript.async = true;
+    gaScript.src = `https://www.googletagmanager.com/gtag/js?id=${analyticsId}`;
+    document.head.appendChild(gaScript);
+
+    window.dataLayer = window.dataLayer || [];
+
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+
+    window.gtag = gtag;
+
+    gtag("js", new Date());
+    gtag("config", analyticsId);
+  }
 </script>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600&display=swap" rel="stylesheet">
 <style>


### PR DESCRIPTION
## Summary

This PR moves the Google Analytics Measurement ID out of `web/index.html` and into the configurable `web/config.js` setup.

Fixes #1

### Changes

* Added an optional `analyticsId` field to `web/config.example.js`
* Load Google Analytics only when `CAREEROPS_CONFIG.analyticsId` is set
* Documented the new configuration option in `web/README.md`

## Type

* [x] Bug fix
* [ ] Feature
* [x] Docs / deploy
* [ ] Chore

## Checklist

* [x] No secrets or personal data in the diff (`web/config.js` not committed)
* [x] Docs updated if behavior or deploy steps changed
* [x] I agree this contribution is under Apache-2.0
