### PR TITLE
Document no-assignment house rule in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,8 @@ Never commit `web/config.js`.
 
 ## Pull requests
 
+**House rule: no assignments.** We do not assign issues. Comment which issue you’re taking if you want, then open a PR. Clean PRs get merged; no PR means the issue stays open for anyone.
+
 1. Open an issue for non-trivial changes (bug / feature).
 2. Branch from `main`.
 3. Keep diffs focused. Match existing style in `web/`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a clear house rule to `CONTRIBUTING.md`: we don’t assign issues — open a PR. Clean PRs get merged; no PR means the issue stays open for anyone.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Docs / deploy
- [ ] Chore

## Checklist

- [x] No secrets or personal data in the diff (`web/config.js` not committed)
- [x] Docs updated if behavior or deploy steps changed
- [x] I agree this contribution is under Apache-2.0

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a9c699f-3e5c-4ea1-8208-2ba926e9c72f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a9c699f-3e5c-4ea1-8208-2ba926e9c72f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

