### PR TITLE
Improve empty-board / first-run guidance copy

### DIFF
--- a/web/ui/state.mjs
+++ b/web/ui/state.mjs
@@ -1349,7 +1349,13 @@ async function load(){
       ? ` · showing ${hiddenN} filtered Sourced`
       : ` · <span class="hidden-chip" id="status_hidden" title="Soft-hidden Sourced: off-lane titles, wrong country, blocklist, over-age, or wrong remote pref. Click to reveal.">${hiddenN} filtered Sourced — show</span>`)
     : (FIND_SHOW_HIDDEN ? ' · <span class="hidden-chip" id="status_hidden">hide filtered again</span>' : '')
-  $('status').innerHTML = active+' active on board'+hiddenBit+' · click a card to check fit · drag between columns'
+  if (active === 0) {
+  $('status').innerHTML =
+    'No roles yet · Run a job search, review LinkedIn, then add a role to <b>Researched</b> · You apply yourself · Paste real job descriptions instead of careers-page scrapes.'
+  } else {
+  $('status').innerHTML =
+    active + ' active on board' + hiddenBit + ' · click a card to check fit · drag between columns'
+  }  
   const sh=$('status_hidden')
   if(sh) sh.onclick=()=>{ FIND_SHOW_HIDDEN=!FIND_SHOW_HIDDEN; load() }
   if($('triage')){
@@ -1422,7 +1428,7 @@ async function load(){
       <div class="meta">${mHtml}${vHtml}${doc}${stampHtml}${flag}${locHtml}${compHtml}${ageHtml}</div>
       ${r.url?`<a class="jd" href="${esc(r.url)}" target="_blank" rel="noopener" onclick="event.stopPropagation()">Open JD ↗</a>`:''}
       ${hideBtn}
-    </div>`}).join('') : '<div class="muted" style="font-size:11px;padding:6px">—</div>'
+    </div>`}).join('') : '<div class="muted" style="font-size:11px;padding:8px 6px;line-height:1.4"> No roles yet. Add one to start tracking.</div>'
     return `<div class="col" data-stage="${s}"><h3>${LABEL[s]}<span>${it.length}</span></h3>${
       s==='researched'
         ? `<button type="button" class="col-add" data-add-role="1" title="You found this job — add link + JD">＋ Add role</button>`


### PR DESCRIPTION
## Summary

Improves the first-run experience by replacing the empty board placeholder with clearer guidance and showing a more helpful status message when there are no active roles.

Fixes #5

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Docs / deploy
- [ ] Chore

## Checklist

- [x] No secrets or personal data in the diff (`web/config.js` not committed)
- [ ] Docs updated if behavior or deploy steps changed
- [x] I agree this contribution is under Apache-2.0