### PR TITLE
docs: list edge functions the SPA calls

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -45,3 +45,21 @@ Pure Career OS helpers used by the SPA live in `lib/` (bullet memory, cadence, r
 
 - **Board pack** (`CareerOps_board_pack.json`) — skill modes + Settings import (upsert). Schema v5 adds contacts, posted `comp_range`/`comp_raw`, and profile target band. API keys never exported or imported.
 - **Full JSON** / **CSV** — Settings → Your data.
+
+## Edge functions
+
+> **Source note:** `web/ui/state.mjs` and `web/ui/settings.mjs` call these by name via `sb.functions.invoke(...)`. Reference implementations for most live under [`supabase/functions/`](../supabase/functions/README.md) — deploy those (or your own equivalents) against your Supabase project. **`fetch-jd` and `humanize` are not in this public repo**; self-hosters must supply those (or skip the UI features that call them). Wire the project via `web/config.js`.
+
+| Function | When the UI calls it | Required for a board-only install? |
+|---|---|---|
+| `run-search-mt` | User clicks **Run job search** (or the onboarding "Run my first search") — scans configured company career boards for matching roles. | **Optional.** Board CRUD works without it; you can add roles manually via **＋ Add role**. |
+| `fetch-jd` | Auto-loads a job description from a posting URL — when opening a role's drawer/panel, on ATS "liveness" checks for a card, and after adding a role via LinkedIn/URL search. | **Optional.** You can paste the JD manually via "Edit / paste" instead. |
+| `resume-match` | User clicks **Check my match** to score a resume against a JD. | **Optional if** a BYO OpenAI-compatible key is set in Settings (the match runs client-side instead). **Required** for match scoring otherwise. Claude/Kimi keys on file still go through this function. |
+| `resume-rewrite` | **Tailor resume**, cover letter, and single-bullet rewrite actions. | Same as above — optional with a BYO OpenAI-compat key, otherwise required for AI tailoring. |
+| `chat` | Advise / in-app assistant follow-ups. | Same bypass logic — optional with a BYO OpenAI-compat key, otherwise required for chat/advisor. |
+| `ai-free` | Settings screen, to show remaining free-tier daily uses. | **Optional** — cosmetic for the SPA usage display; free-tier LLM serving is configured server-side. |
+| `humanize` | **Humanize wording** button. | **Optional** — only used if the user has connected an ai-text-humanizer.com account. |
+| `upsert_provider_secret` | Settings save path when storing Claude / Kimi / humanizer secrets. | **Optional.** Without it, Settings falls back to plaintext profile columns for self-host. |
+| `clear_provider_secret` | Settings when removing a stored provider secret. | **Optional.** Same plaintext fallback as above. |
+
+**Minimal viable install:** none of the 9 functions are strictly required. Core board operations (add/drag/tag roles, verdicts, outcomes, notes) call Supabase tables directly (`sb.from('mt_roles')`, etc.), not Edge Functions. Search and JD auto-fetch need `run-search-mt` / `fetch-jd`; AI scoring/tailoring/chat need the rest (or a BYO OpenAI-compat key to skip those three client-side); secret vault helpers are only needed if you want encrypted Settings storage instead of plaintext profile columns.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an **Edge functions** section to `web/README.md` for #4: all nine SPA-invoked Supabase Edge Functions, when the UI calls each, and required vs optional for a board-only install.

Builds on the excellent draft in #15 (thanks @Acacia21-code) and finishes the review feedback that hadn’t been pushed yet:

- Includes `upsert_provider_secret` / `clear_provider_secret` from `web/ui/settings.mjs`
- Source note points at [`supabase/functions/README.md`](../supabase/functions/README.md); calls out that only `fetch-jd` and `humanize` lack public source
- Clarifies OpenAI-compat client bypass vs Claude/Kimi still using edge
- Trailing newline

Closes #4

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Docs / deploy
- [ ] Chore

## Checklist

- [x] No secrets or personal data in the diff (`web/config.js` not committed)
- [x] Docs updated if behavior or deploy steps changed
- [x] I agree this contribution is under Apache-2.0

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16ed81dc-2659-4cbd-ad4c-e65307e87eaf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16ed81dc-2659-4cbd-ad4c-e65307e87eaf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

