### PR TITLE
docs: update board pack schema version to v5

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -32,7 +32,7 @@ const boards = mergeBoardSources(registry, profile.ats_boards || {})
 
 ## Board pack
 
-Packs stay on `schema_version` 4. Optional additive `extensions`:
+Packs use `schema_version` 5. Optional additive `extensions`:
 
 ```json
 {


### PR DESCRIPTION
## Summary

- Update `docs/PLUGINS.md` to reflect the current Board Pack schema version 5.
- Keep the existing extensions example unchanged.
- Checked for outdated `schema_version 4` references.

Closes #21
