### PR TITLE
Enhance empty state messages in memory and portfolio lists

### DIFF
--- a/web/ui/state.mjs
+++ b/web/ui/state.mjs
@@ -5574,7 +5574,7 @@ function renderMemDiff(from, to){
 function renderMemList(){
   const wrap=$('mem_list'); if(!wrap) return
   const rows=(MEM_ROWS||[]).filter(r=>r.status!=='archived')
-  if(!rows.length){ wrap.innerHTML='<p class="muted" style="font-size:13px">No accomplishments yet — capture one above.</p>'; return }
+  if(!rows.length){ wrap.innerHTML='<div class="empty"><p><strong>No accomplishments yet.</strong> Memory holds raw wins — originals are immutable and never edited.</p><p>Workflow: Capture → Polish (Accept to save polished) → Promote to Portfolio. Enrich from URL tip: paste excerpt works best, LinkedIn may be blocked.</p></div>'; return }
   wrap.innerHTML=rows.map(r=>{
     const st=r.status||'inbox'
     const orig=r.body_original!==r.body_current?`<div class="muted" style="font-size:11.5px;margin-top:4px">Original: ${esc(r.body_original)}</div>`:''
@@ -5813,7 +5813,7 @@ $('mem_save')?.addEventListener('click', async ()=>{
 function renderPfList(){
   const wrap=$('pf_list'); if(!wrap) return
   const rows=(PF_ROWS||[]).filter(r=>!r.archived_at)
-  if(!rows.length){ wrap.innerHTML='<p class="muted" style="font-size:13px">No portfolio items yet.</p>'; return }
+  if(!rows.length){ wrap.innerHTML='<div class="empty"><p><strong>No portfolio items yet.</strong> Portfolio holds polished, reusable stories — used for Tailor and interview.</p><p>To add: Promote from Memory (recommended) or +New.</p></div>'; return }
   wrap.innerHTML=rows.map(r=>`<div class="card" style="padding:12px;margin:8px 0">
     <div style="font-weight:600">${esc(r.title)} <span class="muted" style="font-weight:400">· ${esc(r.item_type)} · ${esc(r.visibility)}</span></div>
     <div style="font-size:13px;margin-top:4px;line-height:1.45">${esc(r.summary||r.body_current||'')}</div>


### PR DESCRIPTION
Updated empty state messages for memory and portfolio lists to provide more context and guidance to users.

## Summary

<!-- What does this PR change, and why? -->

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Docs / deploy
- [ ] Chore

## Checklist

- [ ] No secrets or personal data in the diff (`web/config.js` not committed)
- [ ] Docs updated if behavior or deploy steps changed
- [ ] I agree this contribution is under Apache-2.0
