### PR TITLE
a11y: add skip-to-content link #20

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -731,8 +731,7 @@
     </select></label>
     <span class="muted" id="triage_status">Sourced = new Find adds. Rank Sourced loads JDs from links when possible, then scores — never applies.</span>
   </div>
-   role="tabpanel" aria-labelledby="boardbtn">
-  <div id="stage" class="stage board-only" tabindex="-1"  <div id="board" class="board"></div>
+   <div id="stage" class="stage board-only" role="tabpanel" aria-labelledby="boardbtn" tabindex="-1">  <div id="board" class="board"></div>
     <div id="scrim" class="scrim hidden" aria-hidden="true"></div>
     <aside id="drawer" class="drawer hidden" role="dialog" aria-modal="true">
       <div class="drawer-h">

--- a/web/index.html
+++ b/web/index.html
@@ -537,8 +537,7 @@
 
 /* a11y: skip-to-content #20 */
 .skip-link{position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;background:var(--navy);color:#fff;padding:8px 12px;z-index:9999;border-radius:6px;text-decoration:none;font-weight:600}
-.skip-link:focus{left:8px;top:8px;width:auto;height:auto}
-#stage:focus{outline:none}</style></head><body>
+.skip-link:focus{left:8px;top:8px;width:auto;height:auto}</style></head><body>
 <a class="skip-link" href="#stage">Skip to main content</a>
 
 <!-- =========== AUTH =========== -->
@@ -731,7 +730,8 @@
     </select></label>
     <span class="muted" id="triage_status">Sourced = new Find adds. Rank Sourced loads JDs from links when possible, then scores — never applies.</span>
   </div>
-   <div id="stage" class="stage board-only" role="tabpanel" aria-labelledby="boardbtn" tabindex="-1">  <div id="board" class="board"></div>
+  <div id="stage" class="stage board-only" role="tabpanel" aria-labelledby="boardbtn" tabindex="-1">
+    <div id="board" class="board"></div>
     <div id="scrim" class="scrim hidden" aria-hidden="true"></div>
     <aside id="drawer" class="drawer hidden" role="dialog" aria-modal="true">
       <div class="drawer-h">

--- a/web/index.html
+++ b/web/index.html
@@ -535,9 +535,13 @@
   #bv_err,#bv_err_empty{color:#b42318;font-size:13px;line-height:1.45;min-height:0;margin:8px 0 0}
   #bv_err:empty,#bv_err_empty:empty{display:none}
 
-</style></head><body>
+/* a11y: skip-to-content #20 */
+.skip-link{position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;background:var(--navy);color:#fff;padding:8px 12px;z-index:9999;border-radius:6px;text-decoration:none;font-weight:600}
+.skip-link:focus{left:8px;top:8px;width:auto;height:auto}
+#stage:focus{outline:none}</style></head><body>
+<a class="skip-link" href="#stage">Skip to main content</a>
 
-<!-- ============ AUTH ============ -->
+<!-- =========== AUTH =========== -->
 <div id="auth" class="wrap">
   <div class="card" style="max-width:440px;margin:8vh auto">
     <h1 style="margin:0 0 2px;color:var(--navy)">CareerOps</h1><p style="margin:0 0 4px;color:var(--blue);font-weight:600;font-size:12px;letter-spacing:.5px">by Telivity</p>
@@ -727,8 +731,8 @@
     </select></label>
     <span class="muted" id="triage_status">Sourced = new Find adds. Rank Sourced loads JDs from links when possible, then scores — never applies.</span>
   </div>
-  <div id="stage" class="stage board-only" role="tabpanel" aria-labelledby="boardbtn">
-    <div id="board" class="board"></div>
+   role="tabpanel" aria-labelledby="boardbtn">
+  <div id="stage" class="stage board-only" tabindex="-1"  <div id="board" class="board"></div>
     <div id="scrim" class="scrim hidden" aria-hidden="true"></div>
     <aside id="drawer" class="drawer hidden" role="dialog" aria-modal="true">
       <div class="drawer-h">


### PR DESCRIPTION
## Summary
Fixes #20 — Add skip-to-content link as first child of <body> targeting #stage with tabindex="-1". Includes visually-hidden CSS that becomes visible on :focus.

## Type
- [x] Feature

## Checklist
- [x] No secrets or personal data in the diff (web/config.js not committed)
- [x] Docs updated if behavior or deploy steps changed
- [x] I agree this contribution is under Apache-2.0

Closes #20