### PR TITLE
fix(ui): richer empty guidance for Memory and Portfolio lists

### DIFF
--- a/web/ui/state.mjs
+++ b/web/ui/state.mjs
@@ -5574,7 +5574,7 @@ function renderMemDiff(from, to){
 function renderMemList(){
   const wrap=$('mem_list'); if(!wrap) return
   const rows=(MEM_ROWS||[]).filter(r=>r.status!=='archived')
-  if(!rows.length){ wrap.innerHTML='<p class="muted" style="font-size:13px">No accomplishments yet — capture one above.</p>'; return }
+  if(!rows.length){ wrap.innerHTML='<p class="muted" style="font-size:13px">No accomplishments yet. Capture one above, or paste a GitHub or LinkedIn URL under "Enrich from URL" (paste an excerpt too — LinkedIn fetch may be blocked). After adding: <b>Polish</b> to improve wording → <b>Accept</b> to confirm → <b>Promote</b> to add it to your resume.</p>'; return }
   wrap.innerHTML=rows.map(r=>{
     const st=r.status||'inbox'
     const orig=r.body_original!==r.body_current?`<div class="muted" style="font-size:11.5px;margin-top:4px">Original: ${esc(r.body_original)}</div>`:''
@@ -5813,7 +5813,7 @@ $('mem_save')?.addEventListener('click', async ()=>{
 function renderPfList(){
   const wrap=$('pf_list'); if(!wrap) return
   const rows=(PF_ROWS||[]).filter(r=>!r.archived_at)
-  if(!rows.length){ wrap.innerHTML='<p class="muted" style="font-size:13px">No portfolio items yet.</p>'; return }
+  if(!rows.length){ wrap.innerHTML='<p class="muted" style="font-size:13px">No portfolio items yet. Add code, design, or product proof above. Only items marked <b>Resume OK</b> feed the builder — private items stay hidden.</p>'; return }
   wrap.innerHTML=rows.map(r=>`<div class="card" style="padding:12px;margin:8px 0">
     <div style="font-weight:600">${esc(r.title)} <span class="muted" style="font-weight:400">· ${esc(r.item_type)} · ${esc(r.visibility)}</span></div>
     <div style="font-size:13px;margin-top:4px;line-height:1.45">${esc(r.summary||r.body_current||'')}</div>


### PR DESCRIPTION
## Problem

Memory and Portfolio empty states show a single muted line ("No accomplishments yet — capture one above." / "No portfolio items yet.") with no guidance on what to do next. First-run users bounce because they don't know the capture → polish → accept → promote flow, or that only `resume_ok` portfolio items feed the builder.

## Fix

Replaced both empty-state messages with actionable guidance:

- **Memory:** explains capture, Enrich from URL (with paste fallback note for LinkedIn), and the Polish → Accept → Promote flow.
- **Portfolio:** explains adding items and that only "Resume OK" items feed the builder — private items stay hidden.

No new dependencies. No UI redesign. Matches existing Telivity chrome and `muted` styling.

## Test Plan

- [x] `npm run test:web` passes (smoke-web, test-nav-sections, test-board-layout)
- [x] Empty Memory state answers "what do I do next?" without the README
- [x] Empty Portfolio state explains `resume_ok` vs private visibility
- [x] No layout shift for mouse users
- [x] Narrow window / mobile still readable

Closes #19
